### PR TITLE
Add Typing To Wikipedia Class

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Thank you for considering contributing!
+
+Before opening a PR, please follow this rule:
+
+- Make sure it's not a minor fixes.
+- Discuss changes you've made out on our [Discord Server](https://discord.gg/wP7rxYu8GM) to ease things up.
+- Check if someone hasn't worked on the same thing already.

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ Client.on('guildMemberAdd', async member => {
 **Example**
 
 ```js
-const Wikipedia = require('ultrax')
+const ultrax = require('ultrax')
 const prefix = "!" // require bots prefix
 client.on('message', message => { // Client's message event
     if (!message.content.startsWith(prefix) || message.author.bot) return;
@@ -510,7 +510,7 @@ client.on('message', message => { // Client's message event
         let query = args.join(" ") //using args to define a search query, exmaple usage !wikipdia earth
 
         if (!query) return message.channel.send('Please provide a search query') // Sending a message if a user does not provide a search query
-        const res = new Wikipedia({ // Inistigating the wikipedia class
+        const res = new ultrax.Wikipedia({ // Inistigating the wikipedia class
             message: message, //The message
             color: "RED", //Color of embed that will be sent
             query: query //what the search query is

--- a/classes/wikipedia.js
+++ b/classes/wikipedia.js
@@ -1,13 +1,14 @@
 const fetch = require('node-fetch')
-const { MessageEmbed } = require('discord.js')
+const Discord = require('discord.js')
+
 class Wikipeida {
   /**
    * @name Wikipedia
    * @kind constructor
-   * @param {any} [options.message] the discord message
-   * @param {string} [options.title] title of the embed
-   * @param {string} [options.color] color of embed 
-    * @param {string} [options.query] search query
+   * @param {Discord.Message} options.message The message
+   * @param {String} [options.title] Title of the embed
+   * @param {Discord.ColorResolvable} options.color Color of the embed 
+   * @param {String} options.query The search query
   */
 
   constructor(options) {
@@ -37,7 +38,7 @@ class Wikipeida {
     }
     try {
       if (response.type === 'disambiguation') {
-        const embed = new MessageEmbed()
+        const embed = new Discord.MessageEmbed()
           .setTitle(response.title)
           .setColor(this.color)
           .setURL(response.content_urls.desktop.page)
@@ -47,7 +48,7 @@ class Wikipeida {
                 Other Links for the same topic: [Click Me!](${response.content_urls.desktop.page}).`])
           this.message.channel.send(embed)
       } else {
-        const fullEmbed = new MessageEmbed()
+        const fullEmbed = new Discord.MessageEmbed()
           .setTitle(response.title)
           .setColor(this.color)
           .setURL(response.content_urls.desktop.page)
@@ -56,7 +57,7 @@ class Wikipeida {
           this.message.channel.send(fullEmbed)
       }
     } catch (e) {
-      this.message.channel.send(new MessageEmbed().setDescription(`:x: | No results for ${this.query}`).setColor("RED"))
+      this.message.channel.send(new Discord.MessageEmbed().setDescription(`:x: | No results for ${this.query}`).setColor("RED"))
     }
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,14 @@ import { Client, MessageAttachment, MessageEmbed } from "discord.js";
  */
 declare module "ultrax";
 
+export class Wikipedia {
+
+    constructor(options: WikipediaOptions);
+
+    public fetch(): Promise<void>;
+
+}
+
 export function sleep(milliseconds: number): Promise<void>;
 
 export function passGen(Length: number): string;
@@ -35,6 +43,13 @@ interface ButtonOptions {
 interface WelcomeImageSettingOptions {
     font?: string;
     attachtmentName?: string;
+}
+
+interface WikipediaOptions {
+    message: string;
+    title?: string;
+    color: string;
+    query: string;
 }
 
 type ButtonStyleOptions = "green" | "red" | "blurple" | "grey" | "url";

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Client, MessageAttachment, MessageEmbed } from "discord.js";
+import { Client, MessageAttachment, MessageEmbed, Message, ColorResolvable } from "discord.js";
 
 /**
  * Code and detailed explanation for UltraX package
@@ -46,9 +46,9 @@ interface WelcomeImageSettingOptions {
 }
 
 interface WikipediaOptions {
-    message: string;
+    message: Message;
     title?: string;
-    color: string;
+    color: ColorResolvable;
     query: string;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "UltraX-Package",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ultrax",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "UltraX Package is a unique package that allows you to create cool things using simple functions and make it faster, for example there is an invite logger, discord buttons paginator, etc...",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
PR #2 has some mistakes within optional params in the class which could confuse some users when it comes to typing so I fix and add typing to the `Wikipedia` class.

# Change Logs:
- Add typing for `Wikipedia` ([`5b4d7b4`](https://github.com/KarimX32/UltraX-Package/commit/5b4d7b4696791f29670de341af00f9199dd4df77))
   - Fixed for optional params as well. 
- Fixed typo on README ([`0151688`](https://github.com/KarimX32/UltraX-Package/commit/01516880e118da801f758ac415156fc2460efa42)) 
   - Found a mistake/typo in the README
-  Add a **Terms of Service** for future contributing ([`cce8fef`](https://github.com/KarimX32/UltraX-Package/commit/cce8fefeec5cdd10c8dca4da25ee91b9fecdc410))
   - This will allow users to understand the contribution system before opening a PR 👍🏻 

Let me know if there are some mistakes needed to be fixed/removed.  